### PR TITLE
Postgresq 9.6/14 instalation order

### DIFF
--- a/protect.Dockerfile
+++ b/protect.Dockerfile
@@ -62,7 +62,8 @@ RUN --mount=target=/var/lib/apt/lists,type=cache --mount=target=/var/cache/apt,t
         | tee /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg >/dev/null \
     && echo "deb https://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" > /etc/apt/sources.list.d/postgresql.list \
     && apt-get update \
-    && apt-get --no-install-recommends -y install postgresql-14 postgresql-9.6
+    && apt-get --no-install-recommends -y install postgresql-9.6 \
+    && apt-get --no-install-recommends -y install postgresql-14 
 
 COPY firmware/version /usr/lib/version
 COPY files/lib /lib/


### PR DESCRIPTION
On some environments (probably) apt command with two versions installs version 14 first, which leads to configuration of default pg cluster with version 14 instead 9.6. And because of this later step with `pg_dropcluster --stop 9.6 main` are failing.

I'm not sure why we need default cluster at all, if we are deleting it later. But I assume that it might be important for some installation or bootstrapping process of unifi protect it self.

Any way, this small fix should resolve failed builds in some envs.